### PR TITLE
script parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Script `hsc` supports following options
 - username: -u or --username -> username of hackerrank profile
 - password: -p or --password -> password of hackerrank profile
 - limit:    -l or --limit    -> no. of solutions to be downloaded
+- offset:   -o or --offset   -> crawl solutions starting from this number
 - config:   -c or --config   -> path of config file
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -9,3 +9,27 @@ Crawls solutions of hackerrank and stores as local files.
 - Login with your Hackerrank Credentials
 - Enter the limit of successful solutions you want to be crawled
 - A new folder with name **Hackerrank** would be created with all your solutions in it
+
+## Options to use while running script
+Script `hsc` supports following options
+- help:     -h or --help
+- username: -u or --username -> username of hackerrank profile
+- password: -p or --password -> password of hackerrank profile
+- limit:    -l or --limit    -> no. of solutions to be downloaded
+- config:   -c or --config   -> path of config file
+
+Usage:
+We can use above script helpers as
+```bash
+hsc -l 34 -p testpassword -u testuser
+```
+
+We can also use config file to download solutions
+Let config file be /etc/user.yaml
+```yaml
+username: testuser
+```
+
+```bash
+hsc -c /etc/user.yaml -l 34 -p testpassword
+```

--- a/hsc/crawler.py
+++ b/hsc/crawler.py
@@ -238,8 +238,9 @@ def main():
 
 	crawler = Crawler()
 	crawler.parse_script()
-	while(not crawler.authenticate()):
-		print('Auth was unsuccessful')
+	if not crawler.authenticate():
+		print('Auth was unsuccessful. Exiting the program')
+		exit(1)
 
 	limit = crawler.options.limit or crawler.total_submissions
 	offset = crawler.options.offset or 0

--- a/hsc/crawler.py
+++ b/hsc/crawler.py
@@ -119,8 +119,9 @@ class Crawler:
 		p = configargparse.ArgParser(default_config_files=['./user.yaml'])
 		p.add('-c', '--config', is_config_file=True, help='config file path')
 		p.add('-l', '--limit', help='limit to no. of solutions to be crawled')
-		p.add('-u', '--username', help='username')
-		p.add('-p', '--password', help='password')
+		p.add('-o', '--offset', help='crawl solutions starting from this number')
+		p.add('-u', '--username', help='hackerrank account username')
+		p.add('-p', '--password', help='hackerrank account password')
 
 		self.options = p.parse_args()
 
@@ -234,15 +235,15 @@ class Crawler:
 		print('All Solutions Crawled')
 
 def main():
-	offset = 0
 
 	crawler = Crawler()
 	crawler.parse_script()
 	while(not crawler.authenticate()):
 		print('Auth was unsuccessful')
 
-	limit = crawler.options.limit or crawler.get_number_of_submissions()
-	print('Start crawling {} solutions.....'.format(limit))
+	limit = crawler.options.limit or crawler.total_submissions
+	offset = crawler.options.offset or 0
+	print('Start crawling {} solutions starting from {}'.format(limit, offset))
 	all_submissions_url = crawler.get_all_submissions_url(offset, limit)
 
 	resp = crawler.session.get(all_submissions_url, headers=crawler.headers)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
             'hsc=hsc.crawler:main',
         ],
     },
-    install_requires=['progress', 'requests']
+    install_requires=['progress', 'requests', 'configargparse']
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='hsc',
-    version='1.1.3',
+    version='1.2.0',
     author='Nullifiers',
     author_email='nullifiersorg@gmail.com',
     description='Hackerrank Solution Crawler',


### PR DESCRIPTION
	
# Related Issue	
Closes #23
Closes #24
Closes #28 

## Options to use while running script
Script `hsc` supports following options
- help:     -h or --help
- username: -u or --username -> username of hackerrank profile
- password: -p or --password -> password of hackerrank profile
- limit:    -l or --limit    -> no. of solutions to be downloaded
- config:   -c or --config   -> path of config file

Usage:
We can use above script helpers as
```bash
hsc -l 34 -p testpassword -u testuser
```

We can also use config file to download solutions
Let config file be /etc/user.yaml
```yaml
username: testuser
```

```bash
hsc -c /etc/user.yaml -l 34 -p testpassword
```
