### PR TITLE
fix error on login with outdated version in user-agent

### DIFF
--- a/hsc/crawler.py
+++ b/hsc/crawler.py
@@ -9,7 +9,7 @@ from .constants import extensions
 
 class Crawler:
 	base_url = 'https://www.hackerrank.com/'
-	user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0'
+	user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 Edg/85.0.564.63'
 	login_url = base_url + 'auth/login'
 	submissions_url = base_url + 'rest/contests/master/submissions/?offset={}&limit={}'
 	challenge_url = base_url + 'rest/contests/master/challenges/{}/submissions/{}'


### PR DESCRIPTION
A long term fix would be to add the user-agent to the input params perhaps.

<!-- Fill out this template to explain your pull request. -->	
	
# Related Issue	
<!-- Please link to any related GitHub Issue. -->	
<!-- If none, please create an issue -->

When using hsc there is an error when running .json() on the request. I tried running the request and found that the content showed an error related to the browser version.

# Changes Proposed	
<!-- Describe the changes you've made so it's easier for the team to review. -->	

Temporarily just update the user-agent string, long-term make a new parameter for it or add some library or service call to grab an up to date version.

#### Caveats	
<!-- If there is anything hacky or unique being added in your code please define it.--> 

No, one liner.