### PR TITLE
change login url

### DIFF
--- a/hsc/crawler.py
+++ b/hsc/crawler.py
@@ -10,7 +10,7 @@ from .constants import extensions
 class Crawler:
 	base_url = 'https://www.hackerrank.com/'
 	user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 Edg/85.0.564.63'
-	login_url = base_url + 'auth/login'
+	login_url = base_url + 'rest/auth/login'
 	submissions_url = base_url + 'rest/contests/master/submissions/?offset={}&limit={}'
 	challenge_url = base_url + 'rest/contests/master/challenges/{}/submissions/{}'
 	domain_url = base_url + 'domains/{}'
@@ -234,6 +234,7 @@ def main():
 	data = resp.json()
 	models = data['models']
 	crawler.get_submissions(models)
+
 
 if __name__ == "__main__":
 	main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='hsc',
-    version='1.2.4-alpha',
+    version='1.2.5',
     author='Nullifiers',
     author_email='nullifiersorg@gmail.com',
     description='Hackerrank Solution Crawler',


### PR DESCRIPTION
<!-- Fill out this template to explain your pull request. -->	
	
# Related Issue	
Fix https://github.com/Nullifiers/Hackerrank-Solution-Crawler/issues/48
<!-- Please link to any related GitHub Issue. -->	
<!-- If none, please create an issue -->


# Changes Proposed	
Hackerrank now uses /rest/auth/login for REST logins
updated url on basis of that
<!-- Describe the changes you've made so it's easier for the team to review. -->	
